### PR TITLE
[feature][v0.0.1] split KeyCondition & FilterExpression in builder

### DIFF
--- a/templates/v2/query_builder.go
+++ b/templates/v2/query_builder.go
@@ -74,18 +74,30 @@ func NewQueryBuilder() *QueryBuilder {
     }
 }
 
-{{range .AllAttributes}}
-// With{{ToSafeName .Name | ToUpperCamelCase}} sets the value for the "{{.Name}}" attribute in the query.
-// This method enables filtering and key conditions based on the {{.Name}} field.
+{{range .Attributes}}
+// With{{ToSafeName .Name | ToUpperCamelCase}} sets the key condition for "{{.Name}}" attribute.
+// This method sets KeyConditionExpression for DynamoDB Query operation.
 //
-// DynamoDB attribute: "{{.Name}}" (type: {{.Type}})
+// DynamoDB key attribute: "{{.Name}}" (type: {{.Type}})
 // Go parameter type: {{ToGolangBaseType .Type}}
-//
-// Usage:
-//   query.With{{ToSafeName .Name | ToUpperCamelCase}}({{ToSafeName .Name | ToLowerCamelCase}}) // Sets {{.Name}} = {{ToSafeName .Name | ToLowerCamelCase}}
 //
 // Returns the QueryBuilder for method chaining.
 func (qb *QueryBuilder) With{{ToSafeName .Name | ToUpperCamelCase}}({{ToSafeName .Name | ToLowerCamelCase}} {{ToGolangBaseType .Type}}) *QueryBuilder {
+    qb.Attributes["{{.Name}}"] = {{ToSafeName .Name | ToLowerCamelCase}}
+    qb.UsedKeys["{{.Name}}"] = true
+    return qb
+}
+{{end}}
+
+{{range .CommonAttributes}}
+// Filter{{ToSafeName .Name | ToUpperCamelCase}} sets the filter condition for "{{.Name}}" attribute.
+// This method adds FilterExpression condition to DynamoDB Query operation.
+//
+// DynamoDB filter attribute: "{{.Name}}" (type: {{.Type}})
+// Go parameter type: {{ToGolangBaseType .Type}}
+//
+// Returns the QueryBuilder for method chaining.
+func (qb *QueryBuilder) Filter{{ToSafeName .Name | ToUpperCamelCase}}({{ToSafeName .Name | ToLowerCamelCase}} {{ToGolangBaseType .Type}}) *QueryBuilder {
     qb.Attributes["{{.Name}}"] = {{ToSafeName .Name | ToLowerCamelCase}}
     qb.UsedKeys["{{.Name}}"] = true
     return qb

--- a/tests/localstack/complex_test.go
+++ b/tests/localstack/complex_test.go
@@ -331,13 +331,13 @@ func testComplexQueryBuilder(t *testing.T, client *dynamodb.Client, ctx context.
 			{"WithCreatedAt", func() *complex.QueryBuilder { return qb.WithCreatedAt(123) }},
 			{"WithLikes", func() *complex.QueryBuilder { return qb.WithLikes(10) }},
 			{"WithIsPublished", func() *complex.QueryBuilder { return qb.WithIsPublished(1) }},
-			{"WithTitle", func() *complex.QueryBuilder { return qb.WithTitle("test") }},
-			{"WithContent", func() *complex.QueryBuilder { return qb.WithContent("test") }},
-			{"WithCategory", func() *complex.QueryBuilder { return qb.WithCategory("test") }},
-			{"WithTag", func() *complex.QueryBuilder { return qb.WithTag("test") }},
-			{"WithViews", func() *complex.QueryBuilder { return qb.WithViews(100) }},
-			{"WithIsPremium", func() *complex.QueryBuilder { return qb.WithIsPremium(true) }},
-			{"WithIsFeatured", func() *complex.QueryBuilder { return qb.WithIsFeatured(false) }},
+			{"WithTitle", func() *complex.QueryBuilder { return qb.FilterTitle("test") }},
+			{"WithContent", func() *complex.QueryBuilder { return qb.FilterContent("test") }},
+			{"WithCategory", func() *complex.QueryBuilder { return qb.FilterCategory("test") }},
+			{"WithTag", func() *complex.QueryBuilder { return qb.FilterTag("test") }},
+			{"WithViews", func() *complex.QueryBuilder { return qb.FilterViews(100) }},
+			{"WithIsPremium", func() *complex.QueryBuilder { return qb.FilterIsPremium(true) }},
+			{"WithIsFeatured", func() *complex.QueryBuilder { return qb.FilterIsFeatured(false) }},
 		}
 		for _, method := range methods {
 			result := method.call()
@@ -380,9 +380,9 @@ func testComplexQueryBuilderChaining(t *testing.T) {
 			WithPostId("complex-post").
 			WithCreatedAtGreaterThan(1640995000).
 			WithLikesLessThan(100).
-			WithCategory("tech").
-			WithTag("golang").
-			WithIsPremium(true).
+			FilterCategory("tech").
+			FilterTag("golang").
+			FilterIsPremium(true).
 			OrderByDesc().
 			Limit(25)
 
@@ -391,7 +391,7 @@ func testComplexQueryBuilderChaining(t *testing.T) {
 		qb2 := complex.NewQueryBuilder().
 			WithUserId("user").
 			WithIsPublished(1).
-			WithCategory("tech").
+			FilterCategory("tech").
 			OrderByAsc().
 			Limit(50)
 
@@ -427,9 +427,9 @@ func testComplexQueryBuilderExecution(t *testing.T, client *dynamodb.Client, ctx
 	t.Run("build_query_with_multiple_filters", func(t *testing.T) {
 		qb := complex.NewQueryBuilder().
 			WithUserId("filter-user").
-			WithCategory("tech").
-			WithTag("golang").
-			WithIsPremium(true).
+			FilterCategory("tech").
+			FilterTag("golang").
+			FilterIsPremium(true).
 			WithViewsGreaterThan(100)
 
 		queryInput, err := qb.BuildQuery()
@@ -640,11 +640,11 @@ func testComplexCompositeKeyIndexes(t *testing.T, client *dynamodb.Client, ctx c
 		}{
 			{
 				"category_published_query",
-				complex.NewQueryBuilder().WithCategory("tech").WithIsPublished(1),
+				complex.NewQueryBuilder().FilterCategory("tech").WithIsPublished(1),
 			},
 			{
 				"tag_published_query",
-				complex.NewQueryBuilder().WithTag("golang").WithIsPublished(1),
+				complex.NewQueryBuilder().FilterTag("golang").WithIsPublished(1),
 			},
 		}
 		for _, test := range compositeTests {
@@ -882,8 +882,10 @@ func testComplexCreateKeyFromItem(t *testing.T) {
 		assert.Contains(t, key, "post_id", "Extracted key should contain range key 'post_id'")
 
 		// Validate non-key attributes are excluded
-		nonKeyAttrs := []string{"created_at", "likes", "is_published", "title", "content",
-			"category", "tag", "views", "is_premium", "is_featured"}
+		nonKeyAttrs := []string{
+			"created_at", "likes", "is_published", "title", "content",
+			"category", "tag", "views", "is_premium", "is_featured",
+		}
 		for _, attr := range nonKeyAttrs {
 			assert.NotContains(t, key, attr, "Extracted key should not contain non-key attribute '%s'", attr)
 		}
@@ -944,23 +946,23 @@ func testComplexFilterConditions(t *testing.T, client *dynamodb.Client, ctx cont
 				"multiple_attribute_filters",
 				complex.NewQueryBuilder().
 					WithUserId("filter-user").
-					WithCategory("tech").
-					WithTag("golang").
-					WithIsPremium(false),
+					FilterCategory("tech").
+					FilterTag("golang").
+					FilterIsPremium(false),
 			},
 			{
 				"numeric_and_boolean_filters",
 				complex.NewQueryBuilder().
 					WithUserId("filter-user").
 					WithViewsGreaterThan(150).
-					WithIsFeatured(true),
+					FilterIsFeatured(true),
 			},
 			{
 				"range_and_equality_filters",
 				complex.NewQueryBuilder().
 					WithUserId("filter-user").
 					WithCreatedAtBetween(1640995050, 1640995150).
-					WithCategory("tech"),
+					FilterCategory("tech"),
 			},
 		}
 		for _, test := range filterTests {

--- a/tests/localstack/simple_test.go
+++ b/tests/localstack/simple_test.go
@@ -294,10 +294,10 @@ func testSimpleQueryBuilder(t *testing.T, client *dynamodb.Client, ctx context.C
 		qb3 := qb.WithCreated(1640995200)
 		require.NotNil(t, qb3, "WithCreated should return QueryBuilder for chaining")
 
-		qb4 := qb.WithName("test-name")
+		qb4 := qb.FilterName("test-name")
 		require.NotNil(t, qb4, "WithName should return QueryBuilder for chaining")
 
-		qb5 := qb.WithAge(25)
+		qb5 := qb.FilterAge(25)
 		require.NotNil(t, qb5, "WithAge should return QueryBuilder for chaining")
 
 		t.Logf("✅ All fluent API methods support proper method chaining")
@@ -331,8 +331,8 @@ func testSimpleQueryBuilderChaining(t *testing.T) {
 		qb := simple.NewQueryBuilder().
 			WithId("chain-test").
 			WithCreated(1640995200).
-			WithName("Chained Query").
-			WithAge(35).
+			FilterName("Chained Query").
+			FilterAge(35).
 			OrderByDesc().
 			Limit(25)
 
@@ -341,9 +341,9 @@ func testSimpleQueryBuilderChaining(t *testing.T) {
 	})
 
 	t.Run("method_order_independence", func(t *testing.T) {
-		qb1 := simple.NewQueryBuilder().WithId("test1").OrderByDesc().WithAge(25)
-		qb2 := simple.NewQueryBuilder().OrderByDesc().WithAge(25).WithId("test1")
-		qb3 := simple.NewQueryBuilder().WithAge(25).WithId("test1").OrderByDesc()
+		qb1 := simple.NewQueryBuilder().WithId("test1").OrderByDesc().FilterAge(25)
+		qb2 := simple.NewQueryBuilder().OrderByDesc().FilterAge(25).WithId("test1")
+		qb3 := simple.NewQueryBuilder().FilterAge(25).WithId("test1").OrderByDesc()
 
 		require.NotNil(t, qb1, "Chaining order 1 should work")
 		require.NotNil(t, qb2, "Chaining order 2 should work")
@@ -397,8 +397,8 @@ func testSimpleQueryBuilderExecution(t *testing.T, client *dynamodb.Client, ctx 
 	t.Run("build_query_with_filters", func(t *testing.T) {
 		qb := simple.NewQueryBuilder().
 			WithId("filter-test").
-			WithName("Test Name").
-			WithAge(30)
+			FilterName("Test Name").
+			FilterAge(30)
 
 		queryInput, err := qb.BuildQuery()
 		require.NoError(t, err, "BuildQuery with filters should succeed")

--- a/tests/parts/query_builder_test.go
+++ b/tests/parts/query_builder_test.go
@@ -74,14 +74,43 @@ func TestQueryBuilderTemplate(t *testing.T) {
 		assert.Contains(t, rendered, "func NewQueryBuilder() *QueryBuilder", "Should contain NewQueryBuilder constructor")
 	})
 
-	// Test that With<Attribute> methods are generated for all attributes
-	// Example: WithUserId, WithCreatedAt, WithStatus, WithUpdatedAt
-	t.Run("fluent_methods_present", func(t *testing.T) {
-		for _, attr := range templateMap.AllAttributes {
+	// Test that With<Attribute> methods are generated for key attributes only
+	// Example: WithUserId, WithCreatedAt, WithStatus (hash/range keys)
+	t.Run("key_condition_methods_present", func(t *testing.T) {
+		for _, attr := range templateMap.Attributes {
 			name := utils.ToUpperCamelCase(utils.ToSafeName(attr.Name))
 			expected := "With" + name + "("
 			assert.Contains(t, rendered, expected,
-				"Should contain fluent method: %s", expected)
+				"Should contain key condition method: %s", expected)
+		}
+	})
+
+	// Test that Filter<Attribute> methods are generated for non-key attributes only
+	// Example: FilterTitle, FilterContent, FilterViews (filter expressions)
+	t.Run("filter_expression_methods_present", func(t *testing.T) {
+		for _, attr := range templateMap.CommonAttributes {
+			name := utils.ToUpperCamelCase(utils.ToSafeName(attr.Name))
+			expected := "Filter" + name + "("
+			assert.Contains(t, rendered, expected,
+				"Should contain filter expression method: %s", expected)
+		}
+	})
+
+	// Test that key and filter methods are not mixed
+	// Example: key attributes should not have Filter methods, common attributes should not have With methods
+	t.Run("no_mixed_method_types", func(t *testing.T) {
+		for _, attr := range templateMap.Attributes {
+			name := utils.ToUpperCamelCase(utils.ToSafeName(attr.Name))
+			unexpected := "Filter" + name + "("
+			assert.NotContains(t, rendered, unexpected,
+				"Key attribute should not have filter method: %s", unexpected)
+		}
+
+		for _, attr := range templateMap.CommonAttributes {
+			name := utils.ToUpperCamelCase(utils.ToSafeName(attr.Name))
+			unexpected := "With" + name + "("
+			assert.NotContains(t, rendered, unexpected,
+				"Common attribute should not have key method: %s", unexpected)
 		}
 	})
 

--- a/tests/validation/validation.go
+++ b/tests/validation/validation.go
@@ -53,7 +53,7 @@ func CodeCompiles(t *testing.T, code, packageName string) {
 
 	goFileName := fmt.Sprintf("%s.go", packageName)
 	goFilePath := filepath.Join(tempDir, goFileName)
-	if err := os.WriteFile(goFilePath, []byte(code), 0644); err != nil {
+	if err := os.WriteFile(goFilePath, []byte(code), 0o644); err != nil {
 		t.Fatalf("Failed to write Go file: %v", err)
 	}
 	tidyResult := execGoModTidy(t, tempDir)
@@ -181,7 +181,7 @@ func createTempGoFile(t *testing.T, content string) string {
 	tempDir := t.TempDir()
 	testFile := filepath.Join(tempDir, "test.go")
 
-	err := os.WriteFile(testFile, []byte(content), 0644)
+	err := os.WriteFile(testFile, []byte(content), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
@@ -210,7 +210,7 @@ require (
 `
 
 	goModContent := fmt.Sprintf(goModTemplate, goVersion)
-	return os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goModContent), 0644)
+	return os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goModContent), 0o644)
 }
 
 func getCurrentGoVersion() (string, error) {


### PR DESCRIPTION
# What's new

Split KeyCondition & FilterExpression in builder like "With" && "Filter".

# Verification (Docs)

Need to change everywhere in queryBuilder!
[the main part](https://go-dyno.madpixels.io/en/v0.0.1-alpha/guide/usage#filter-conditions)
which should be re-written

# Checks 

- [x] My code follows the project coding style and conventions
- [x] I have tested my changes locally
- [x] I added/updated tests (if needed)

# Issue

#18

# Tag

`[feature]`

---
> 🛎 **Note:** When merging, don't forget to **include the tag** at the beginning of the merge commit message  
> and **add `Resolve #<issue>`** at the end if applicable.