### PR TITLE
[feature][v0.0.1] Add schema validation (type/subtype) proc

### DIFF
--- a/internal/schema/loader.go
+++ b/internal/schema/loader.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Mad-Pixels/go-dyno/internal/schema/common"
@@ -30,6 +31,17 @@ func LoadSchema(path string) (*DynamoSchema, error) {
 	if err := utils.ReadAndParseJSON(path, &schema.schema); err != nil {
 		return nil, err
 	}
+	for _, attr := range schema.schema.Attributes {
+		if err := attr.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid attribute in 'attributes': %v", err)
+		}
+	}
+	for _, attr := range schema.schema.CommonAttributes {
+		if err := attr.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid attribute in 'common_attributes': %v", err)
+		}
+	}
+
 	for i := range schema.schema.SecondaryIndexes {
 		idx := &schema.schema.SecondaryIndexes[i]
 

--- a/tests/data/invalid-empty-name.json
+++ b/tests/data/invalid-empty-name.json
@@ -1,0 +1,10 @@
+{
+  "table_name": "invalid-empty-name",
+  "hash_key": "id", 
+  "attributes": [
+    { "name": "", "type": "S" },
+    { "name": "valid", "type": "N" }
+  ],
+  "common_attributes": [],
+  "secondary_indexes": []
+}

--- a/tests/data/invalid-number-with-string.json
+++ b/tests/data/invalid-number-with-string.json
@@ -1,0 +1,10 @@
+{
+  "table_name": "invalid-number-with-string", 
+  "hash_key": "id",
+  "attributes": [
+    { "name": "id", "type": "S" },
+    { "name": "count", "type": "N", "subtype": "string" }
+  ],
+  "common_attributes": [],
+  "secondary_indexes": []
+}

--- a/tests/data/invalid-string-with-float.json
+++ b/tests/data/invalid-string-with-float.json
@@ -1,0 +1,13 @@
+{
+  "table_name": "invalid-string-with-float",
+  "hash_key": "id",
+  "range_key": "category",
+  "attributes": [
+    { "name": "id", "type": "S" },
+    { "name": "category", "type": "S", "subtype": "float32" }
+  ],
+  "common_attributes": [
+    { "name": "price", "type": "N" }
+  ],
+  "secondary_indexes": []
+}

--- a/tests/data/invalid-unknown-type.json
+++ b/tests/data/invalid-unknown-type.json
@@ -1,0 +1,10 @@
+{
+  "table_name": "invalid-unknown-type",
+  "hash_key": "id",
+  "attributes": [
+    { "name": "id", "type": "S" },
+    { "name": "weird", "type": "UNKNOWN_TYPE" }
+  ],
+  "common_attributes": [],
+  "secondary_indexes": []
+}

--- a/tests/localstack/env/locals.tf
+++ b/tests/localstack/env/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  project     = "applingo"
+  project     = "testing"
   provisioner = "infra"
 
   tags = {
@@ -7,7 +7,13 @@ locals {
     "Test" = "true"
   }
 
-  schema_files = fileset("${path.root}/../../data", "*.json")
+  # Exclude schemas with "invalid-" prefix
+  all_schema_files = fileset("${path.root}/../../data", "*.json")
+  schema_files = [
+    for file in local.all_schema_files : file
+    if !startswith(file, "invalid-")
+  ]
+  
   schemas = {
     for file in local.schema_files :
     trimsuffix(file, ".json") => jsondecode(file("${path.root}/../../data/${file}"))

--- a/tests/localstack/env/locals.tf
+++ b/tests/localstack/env/locals.tf
@@ -13,7 +13,7 @@ locals {
     for file in local.all_schema_files : file
     if !startswith(file, "invalid-")
   ]
-  
+
   schemas = {
     for file in local.schema_files :
     trimsuffix(file, ".json") => jsondecode(file("${path.root}/../../data/${file}"))

--- a/tests/validation/compilation_test.go
+++ b/tests/validation/compilation_test.go
@@ -14,7 +14,7 @@ import (
 // TestGeneratedCodeCompilation validates that complete DynamoDB code generation produces compilable Go code.
 //
 // Test process:
-//  1. Reads JSON schema files from .tmpl/ directory
+//  1. Reads JSON schema files from .tmpl/ directory (skipping files with 'invalid-' prefix)
 //  2. Generates complete Go code using DynamoDB templates
 //  3. Creates temporary module with proper dependencies
 //  4. Runs "go build" to ensure compilation succeeds
@@ -28,6 +28,11 @@ func TestGeneratedCodeCompilation(t *testing.T) {
 	for _, schemaFile := range schemaFiles {
 		schemaFile := schemaFile
 		schemaName := strings.TrimSuffix(filepath.Base(schemaFile), ".json")
+
+		if strings.HasPrefix(schemaName, "invalid-") {
+			t.Logf("Skipping invalid schema for compilation test: %s", schemaName)
+			continue
+		}
 
 		t.Run(schemaName, func(t *testing.T) {
 			t.Parallel()

--- a/tests/validation/fmt_test.go
+++ b/tests/validation/fmt_test.go
@@ -14,7 +14,7 @@ import (
 // TestGeneratedCodeFormatting validates that complete DynamoDB code generation produces properly formatted Go code.
 //
 // Test process:
-//  1. Reads JSON schema files from .tmpl/ directory
+//  1. Reads JSON schema files from .tmpl/ directory (skipping files with 'invalid-' prefix)
 //  2. Generates complete Go code using DynamoDB templates
 //  3. Runs formatting validation (go fmt, goimports, gofumpt)
 //
@@ -27,6 +27,11 @@ func TestGeneratedCodeFormatting(t *testing.T) {
 	for _, schemaFile := range schemaFiles {
 		schemaFile := schemaFile
 		schemaName := strings.TrimSuffix(filepath.Base(schemaFile), ".json")
+
+		if strings.HasPrefix(schemaName, "invalid-") {
+			t.Logf("Skipping invalid schema for compilation test: %s", schemaName)
+			continue
+		}
 
 		t.Run(schemaName, func(t *testing.T) {
 			t.Parallel()

--- a/tests/validation/schema_validation_test.go
+++ b/tests/validation/schema_validation_test.go
@@ -1,0 +1,153 @@
+package validation
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Mad-Pixels/go-dyno/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaValidation tests that invalid JSON schemas are properly rejected
+// during the LoadSchema phase, before any code generation occurs.
+//
+// Test Coverage:
+// - Invalid subtype combinations (string with float, number with string, etc.)
+// - Empty attribute names
+// - Unknown DynamoDB types
+// - Incompatible type/subtype pairs
+//
+// These tests ensure that users get clear error messages for invalid schemas
+// rather than generating broken code or runtime errors.
+func TestSchemaValidation(t *testing.T) {
+	testCases := []struct {
+		name          string
+		schemaFile    string
+		expectError   bool
+		errorContains string
+		description   string
+	}{
+		{
+			name:        "valid_schema_should_pass",
+			schemaFile:  "../data/base-string.json",
+			expectError: false,
+			description: "Valid schema should load without errors",
+		},
+		{
+			name:          "invalid_string_with_float_subtype",
+			schemaFile:    "../data/invalid-string-with-float.json",
+			expectError:   true,
+			errorContains: "float32 is not compatible with DynamoDB type 'S'",
+			description:   "String attribute cannot have float32 subtype",
+		},
+		{
+			name:          "invalid_number_with_string_subtype",
+			schemaFile:    "../data/invalid-number-with-string.json",
+			expectError:   true,
+			errorContains: "string is not compatible with DynamoDB type 'N'",
+			description:   "Number attribute cannot have string subtype",
+		},
+		{
+			name:          "invalid_empty_attribute_name",
+			schemaFile:    "../data/invalid-empty-name.json",
+			expectError:   true,
+			errorContains: "attribute name cannot be empty",
+			description:   "Attribute name cannot be empty",
+		},
+		{
+			name:          "invalid_unknown_dynamodb_type",
+			schemaFile:    "../data/invalid-unknown-type.json",
+			expectError:   true,
+			errorContains: "invalid DynamoDB type 'UNKNOWN_TYPE'",
+			description:   "Unknown DynamoDB types should be rejected",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture loop variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Logf("Testing: %s", tc.description)
+
+			// Resolve absolute path to schema file
+			schemaPath, err := filepath.Abs(tc.schemaFile)
+			require.NoError(t, err, "Should resolve schema file path")
+
+			// Attempt to load the schema
+			loadedSchema, err := schema.LoadSchema(schemaPath)
+
+			if tc.expectError {
+				// Should get an error
+				assert.Error(t, err, "Expected validation error for %s", tc.name)
+				assert.Nil(t, loadedSchema, "Schema should be nil on validation error")
+
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains,
+						"Error should contain expected message for %s", tc.name)
+				}
+
+				t.Logf("✅ Correctly rejected invalid schema: %s", err.Error())
+			} else {
+				// Should succeed
+				assert.NoError(t, err, "Valid schema should load without error")
+				assert.NotNil(t, loadedSchema, "Valid schema should not be nil")
+
+				t.Logf("✅ Valid schema loaded successfully")
+			}
+		})
+	}
+}
+
+// TestValidationErrorMessages ensures error messages are helpful for users
+func TestValidationErrorMessages(t *testing.T) {
+	testCases := []struct {
+		name         string
+		schemaFile   string
+		expectedMsgs []string
+	}{
+		{
+			name:       "subtype_compatibility_error",
+			schemaFile: "../data/invalid-string-with-float.json",
+			expectedMsgs: []string{
+				"invalid attribute",
+				"float32 is not compatible with DynamoDB type 'S'",
+			},
+		},
+		{
+			name:       "empty_name_error",
+			schemaFile: "../data/invalid-empty-name.json",
+			expectedMsgs: []string{
+				"attribute name cannot be empty",
+			},
+		},
+		{
+			name:       "unknown_type_error",
+			schemaFile: "../data/invalid-unknown-type.json",
+			expectedMsgs: []string{
+				"invalid DynamoDB type 'UNKNOWN_TYPE'",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaPath, err := filepath.Abs(tc.schemaFile)
+			require.NoError(t, err, "Should resolve schema path")
+
+			_, err = schema.LoadSchema(schemaPath)
+			require.Error(t, err, "Should get validation error")
+
+			for _, expectedMsg := range tc.expectedMsgs {
+				assert.Contains(t, err.Error(), expectedMsg,
+					"Error message should contain: %s", expectedMsg)
+			}
+
+			t.Logf("✅ Error message contains expected content: %s", err.Error())
+		})
+	}
+}


### PR DESCRIPTION
Resolve 

- Add Validation proc during schema load
- Check that 'type' and 'subtype' are correct

# Checks 

- [x] My code follows the project coding style and conventions
- [x] I have tested my changes locally
- [x] I added/updated tests (if needed)

# Issue

#50

# Tag

`[feature]`

---
> 🛎 **Note:** When merging, don't forget to **include the tag** at the beginning of the merge commit message  
> and **add `Resolve #<issue>`** at the end if applicable.